### PR TITLE
Serve a (hideous) link.html page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 
 LABEL Author="SilaMoney"
-LABEL Version="1.1.0"
+LABEL Version="1.2.0"
 
 
 WORKDIR /signer-server

--- a/signerserver/application.py
+++ b/signerserver/application.py
@@ -8,6 +8,7 @@ Designed for use with the Sila API (https://www.silamoney.com) and Postman.
 import json
 import logging
 import re
+import os
 import uuid
 from datetime import datetime
 
@@ -21,6 +22,8 @@ SET_UUID_HEADER = 'x-set-uuid'
 SET_FILE_HASH_HEADER = 'x-set-file-hash'
 SET_FILE_METADATA_HEADER = 'x-set-file-metadata'
 FORWARD_TO_URL_HEADER = 'x-forward-to-url'
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 logger = logging.getLogger(__name__)
 app = Flask(__name__)
@@ -53,6 +56,14 @@ def generate_private_key():
         "address": address,
         "wallet_verification_signature": keys.sign_message(address.encode('utf-8'), private_key),
     }
+
+
+@app.route('/plaid_link')
+def serve_plaid_link():
+    """Simply serves a static Plaid Link demo page."""
+    with open(BASE_DIR + '/link.html', 'r') as file:
+        file_string = file.read()
+    return file_string
 
 
 @app.route('/forward', methods=['OPTIONS', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'])

--- a/signerserver/link.html
+++ b/signerserver/link.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Plaid Link</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+    <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+</head>
+
+<body>
+
+    <label>Link Token: </label>
+    <input id="link-token-input-field" type="text" required>
+    <button id="link-button">Link Account</button>
+
+    <br>
+    <p id="public-token-response"></p>
+    <p id="metadata-response" style="white-space: pre-wrap"></p>
+
+    <script type="text/javascript">
+        var plaid_link_init_args = {
+            // Create a new link_token to initialize Link
+            //token: '',
+            env: 'sandbox',
+            onSuccess: function (public_token, metadata) {
+                // Send the public_token to your app server.
+                // The metadata object contains info about the institution the
+                // user selected and the account ID or IDs, if the
+                // Select Account view is enabled.
+                console.log('public_token: ' + public_token);
+                console.log('onSuccess metadata: ', metadata);
+                document.getElementById('public-token-response').textContent = 'Public token: ' + public_token;
+                document.getElementById('metadata-response').textContent = 'Metadata:\n' + JSON.stringify(metadata, null, '\t');
+            },
+            onExit: function (err, metadata) {
+                // The user exited the Link flow.
+                // metadata contains information about the institution
+                // that the user selected and the most recent API request IDs.
+                // Storing this information can be helpful for support.
+                if (err != null) {
+                    // The user encountered a Plaid API error prior to exiting.
+                    console.log('error: ', err);
+                }
+                console.log('onExit metadata: ', metadata);
+            },
+            onEvent: function (event_name, metadata) {
+                // Optionally capture Link flow events, streamed through
+                // this callback as your users connect an Item to Plaid.
+                // For example:
+                // event_name = "TRANSITION_VIEW"
+                // metadata  = {
+                //   link_session_id: "123-abc",
+                //   mfa_type:        "questions",
+                //   timestamp:       "2017-09-14T14:42:19.350Z",
+                //   view_name:       "MFA",
+                // }
+                console.log('event_name: ', event_name);
+                console.log('onEvent metadata: ', metadata);
+            }
+        }
+
+        $('#link-button').on('click', function (e) {
+            var form_token = document.getElementById('link-token-input-field').value;
+            console.log('form link token: ', form_token);
+            plaid_link_init_args['token'] = form_token;
+            if (plaid_link_init_args['token']) {
+                var handler = Plaid.create(plaid_link_init_args);
+                handler.open();
+            }
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
I've thought somewhat frequently that it would be handy to actually initialize the Plaid Link interface while debugging, so now this local server can serve this truly ugly Plaid Link page.

Includes a form field for entering a Plaid link token. The plugin is initialized with that token and the public token + metadata are displayed on the page when Plaid completes successfully.

The endpoint on this server is /plaid_link. The page ends up looking like this after Plaid Link has completed:

![image](https://user-images.githubusercontent.com/32368077/105621542-50c19c80-5dbd-11eb-81c2-3fe836aeb064.png)

Credit where credit is due: this HTML mostly comes from Plaid's quickstart https://plaid.com/docs/quickstart/#how-it-works

Improvements to make:

- inline JS -> static file
- add some CSS
- be able to add different parameters to Plaid.create, like env or public_key
- better HTML structure/use forms maybe