### PR TITLE
SILA-1815: updated postman collection to include get_virtual_accounts

### DIFF
--- a/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
+++ b/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
@@ -3568,6 +3568,91 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get Virtual Accounts",
+					"request": {
+						"auth": {
+							"type": "apikey",
+							"apikey": [
+								{
+									"key": "value",
+									"value": "private-key; Authsignature={{app_private_key}}; Usersignature={{user_private_key}}",
+									"type": "string"
+								},
+								{
+									"key": "key",
+									"value": "Authorization",
+									"type": "string"
+								},
+								{
+									"key": "in",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"description": "Forwards to this endpoint on main API host.",
+								"key": "X-Forward-To-URL",
+								"type": "text",
+								"value": "{{host}}/0.2/get_virtual_accounts"
+							},
+							{
+								"description": "Sets epoch on specified JSON key. (Dots indicate nested dictionaries.)",
+								"key": "X-Set-Epoch",
+								"type": "text",
+								"value": "header.created"
+							},
+							{
+								"description": "Sets a random UUID4 string on specified JSON key.",
+								"key": "X-Set-UUID",
+								"type": "text",
+								"value": "header.reference"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\",\n        \"user_handle\": \"{{user_handle}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:{{proxy_port}}/forward?label=get_virtual_accounts",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{proxy_port}}",
+							"path": [
+								"forward"
+							],
+							"query": [
+								{
+									"key": "debug",
+									"value": "true",
+									"description": "Requests that proxy send back debug information about request and response.",
+									"disabled": true
+								},
+								{
+									"key": "label",
+									"value": "get_virtual_accounts"
+								}
+							]
+						},
+						"description": "Gets list of bank accounts linked to the user_handle along with their statuses."
+					},
+					"response": []
 				}
 			]
 		},

--- a/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
+++ b/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
@@ -3650,7 +3650,7 @@
 								}
 							]
 						},
-						"description": "Gets list of bank accounts linked to the user_handle along with their statuses."
+						"description": "This endpoint is used for retrieving all of the virtual accounts that are allocated to an end user."
 					},
 					"response": []
 				}


### PR DESCRIPTION
Adds a new endpoint for the virtual accounts epic.

JIRA
https://sila.atlassian.net/browse/SILA-1815


Confluence
https://sila.atlassian.net/wiki/spaces/PROD/pages/1694040165/API+Endpoints+-+Customer-facing#New:-/get_virtual_accounts

Customer facing documentation
https://docs.silamoney.com/v0.2/reference/get_virtual_accounts?showHidden=634c3

PR in GrandCentral
https://github.com/Sila-Money/grandcentral/pull/1799

Deployment-related concerns:
This is a customer facing change that adds a new vaccount endpoint as part of the Virtual Accounts epic

Epic:
https://sila.atlassian.net/browse/SILA-1627

Milestone:
https://sila.atlassian.net/issues/?jql=labels%20%3D%20%22vAccount_milestone_3%22