### PR TITLE
SILA-1816: add support for get_virtual_account in postman collection

### DIFF
--- a/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
+++ b/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
@@ -3735,7 +3735,7 @@
 								}
 							]
 						},
-						"description": "Gets list of bank accounts linked to the user_handle along with their statuses."
+						"description": "This endpoint is used for retrieving all of the virtual accounts that are allocated to an end user."
 					},
 					"response": []
 				}
@@ -4926,6 +4926,76 @@
 				}
 			],
 			"description": "Contains endpoints which return meta information about how to make requests to this API."
+		},
+		{
+			"name": "Webhooks",
+			"item": [
+				{
+					"name": "Get Webhooks",
+					"request": {
+						"auth": {
+							"type": "apikey",
+							"apikey": [
+								{
+									"key": "value",
+									"value": "private-key; Authsignature={{app_private_key}}",
+									"type": "string"
+								},
+								{
+									"key": "key",
+									"value": "Authorization",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "X-Forward-To-URL",
+								"value": "{{host}}/0.2/get_webhooks",
+								"type": "text"
+							},
+							{
+								"key": "X-Set-Epoch",
+								"value": "header.created",
+								"type": "text"
+							},
+							{
+								"key": "X-Set-UUID",
+								"value": "header.reference",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\",\n        \"user_handle\": \"{{user_handle}}\"\n    },\n    \"search_filters\": {\n    \"uuid\": \"{{some UUID string assigned by Sila}}\",    \n    \"delivered\": {{webhook delivered true|false}},\n    \"sort_ascending\": false,\n    \"event_type\": \"{{webhook event type}}\",\n    \"endpoint_name\": \"{{webhook endpoint name}}\",\n    \"user_handle\": \"{{webhook user handle}}\",\n    \"start_epoch\": \"{{webhook start time}}\",\n    \"end_epoch\": \"{{webhook end time}}\",\n    \"page\": 1,\n    \"per_page\": 20\n  }\n}"
+						},
+						"url": {
+							"raw": "http://localhost:{{proxy_port}}/forward?label=get_webhooks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{proxy_port}}",
+							"path": [
+								"forward"
+							],
+							"query": [
+								{
+									"key": "label",
+									"value": "get_webhooks"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
 			"name": "Proxy Helper: Generate Private Key",

--- a/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
+++ b/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
@@ -3570,6 +3570,91 @@
 					"response": []
 				},
 				{
+					"name": "Get Virtual Account",
+					"request": {
+						"auth": {
+							"type": "apikey",
+							"apikey": [
+								{
+									"key": "value",
+									"value": "private-key; Authsignature={{app_private_key}}; Usersignature={{user_private_key}}",
+									"type": "string"
+								},
+								{
+									"key": "key",
+									"value": "Authorization",
+									"type": "string"
+								},
+								{
+									"key": "in",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"description": "Forwards to this endpoint on main API host.",
+								"key": "X-Forward-To-URL",
+								"type": "text",
+								"value": "{{host}}/0.2/get_virtual_account"
+							},
+							{
+								"description": "Sets epoch on specified JSON key. (Dots indicate nested dictionaries.)",
+								"key": "X-Set-Epoch",
+								"type": "text",
+								"value": "header.created"
+							},
+							{
+								"description": "Sets a random UUID4 string on specified JSON key.",
+								"key": "X-Set-UUID",
+								"type": "text",
+								"value": "header.reference"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\",\n        \"user_handle\": \"{{user_handle}}\"\n    },\n    \"virtual_account_id\": \"{{virtual_account_id}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:{{proxy_port}}/forward?label=get_virtual_account",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "{{proxy_port}}",
+							"path": [
+								"forward"
+							],
+							"query": [
+								{
+									"key": "debug",
+									"value": "true",
+									"description": "Requests that proxy send back debug information about request and response.",
+									"disabled": true
+								},
+								{
+									"key": "label",
+									"value": "get_virtual_account"
+								}
+							]
+						},
+						"description": "Get a single virutal account that is linked to the user_handle. Returns the virtual account statuses and balance information."
+					},
+					"response": []
+				},
+				{
 					"name": "Get Virtual Accounts",
 					"request": {
 						"auth": {
@@ -3650,7 +3735,7 @@
 								}
 							]
 						},
-						"description": "This endpoint is used for retrieving all of the virtual accounts that are allocated to an end user."
+						"description": "Gets list of bank accounts linked to the user_handle along with their statuses."
 					},
 					"response": []
 				}
@@ -4841,76 +4926,6 @@
 				}
 			],
 			"description": "Contains endpoints which return meta information about how to make requests to this API."
-		},
-		{
-			"name": "Webhooks",
-			"item": [
-				{
-					"name": "Get Webhooks",
-					"request": {
-						"auth": {
-							"type": "apikey",
-							"apikey": [
-								{
-									"key": "value",
-									"value": "private-key; Authsignature={{app_private_key}}",
-									"type": "string"
-								},
-								{
-									"key": "key",
-									"value": "Authorization",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "X-Forward-To-URL",
-								"value": "{{host}}/0.2/get_webhooks",
-								"type": "text"
-							},
-							{
-								"key": "X-Set-Epoch",
-								"value": "header.created",
-								"type": "text"
-							},
-							{
-								"key": "X-Set-UUID",
-								"value": "header.reference",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\",\n        \"user_handle\": \"{{user_handle}}\"\n    },\n    \"search_filters\": {\n    \"uuid\": \"{{some UUID string assigned by Sila}}\",    \n    \"delivered\": {{webhook delivered true|false}},\n    \"sort_ascending\": false,\n    \"event_type\": \"{{webhook event type}}\",\n    \"endpoint_name\": \"{{webhook endpoint name}}\",\n    \"user_handle\": \"{{webhook user handle}}\",\n    \"start_epoch\": \"{{webhook start time}}\",\n    \"end_epoch\": \"{{webhook end time}}\",\n    \"page\": 1,\n    \"per_page\": 20\n  }\n}"
-						},
-						"url": {
-							"raw": "http://localhost:{{proxy_port}}/forward?label=get_webhooks",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "{{proxy_port}}",
-							"path": [
-								"forward"
-							],
-							"query": [
-								{
-									"key": "label",
-									"value": "get_webhooks"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
 		},
 		{
 			"name": "Proxy Helper: Generate Private Key",

--- a/postman/SilaSandbox.postman_environment.json
+++ b/postman/SilaSandbox.postman_environment.json
@@ -71,6 +71,11 @@
 			"key": "bank_account_name",
 			"value": "",
 			"enabled": true
+		},
+		{
+			"key": "virtual_account_id",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",


### PR DESCRIPTION
Adds the /get_virtual_account endpoint. This new endpoint customer facing endpoint in the Customer API is used for retrieving a single virtual account and includes the account balances.


Specification:
https://sila.atlassian.net/wiki/spaces/PROD/pages/1694040165/API+Endpoints+-+Customer-facing#New:-/get_virtual_account

Related PR in GrandCentral:
https://github.com/Sila-Money/grandcentral/pull/1821

Ticket
https://sila.atlassian.net/browse/SILA-1816

Customer facing documentation
https://docs.silamoney.com/reference/get_virtual_account?showHidden=634c3