### PR TITLE
ENGRG-934 - cko_public_key

### DIFF
--- a/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
+++ b/postman/Sila API v0.2 - Local Signer Server Edition.postman_collection.json
@@ -6087,7 +6087,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\"\n    },\n    \"type\": \"card\",\n    \"card_number\": 4659105569051157,\n    \"expiry_month\": 12, \n    \"expiry_year\": 2027,\n    \"cvv\": 956\n}",
+							"raw": "{\n    \"header\": {\n        \"app_handle\": \"{{app_handle}}\"\n    },\n    \"cko_public_key\": \"{{cko_public_key}}\",\n    \"type\": \"card\",\n    \"card_number\": 4659105569051157,\n    \"expiry_month\": 12, \n    \"expiry_year\": 2027,\n    \"cvv\": 956\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/postman/SilaSandbox.postman_environment.json
+++ b/postman/SilaSandbox.postman_environment.json
@@ -101,7 +101,12 @@
 			"key": "cko_token",
 			"value": "",
 			"enabled": true
-		}
+		},
+        {
+          "key": "cko_public_key",
+          "value": "",
+          "enabled": true
+        }
 	],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2022-02-07T23:53:44.318Z",


### PR DESCRIPTION
* add `cko_public_key` to the `/create_cko_testing_token` request - must be passed in, no longer stored with the app's CKO credentials